### PR TITLE
fix: prettier formatting in e2e specs (restore green CI lint)

### DIFF
--- a/tests/e2e/achievement-panel.spec.js
+++ b/tests/e2e/achievement-panel.spec.js
@@ -11,17 +11,13 @@ async function startLocalGame(page) {
 }
 
 test.describe('Achievement panel', () => {
-    test('badge is empty on the main menu before any game starts', async ({
-        page,
-    }) => {
+    test('badge is empty on the main menu before any game starts', async ({ page }) => {
         await gotoApp(page);
         // Panel only renders after a game initializes; menu shows the static 0/0 markup.
         await expect(page.locator('#achievementCountBadge')).toHaveText('0/0');
     });
 
-    test('panel renders unlocked achievements via the real render path', async ({
-        page,
-    }) => {
+    test('panel renders unlocked achievements via the real render path', async ({ page }) => {
         await startLocalGame(page);
 
         // After a game starts the badge reflects the total definition count.
@@ -30,20 +26,21 @@ test.describe('Achievement panel', () => {
         );
 
         // Unlock the first two real achievements, then call the genuine renderer.
-        const unlockedCount = await page.evaluate((firstIds) => {
-            const game = window.__shapeKeeperActiveGame;
-            firstIds.forEach((id) => game.achievementSystem.unlock(id));
-            game.renderAchievementPanel();
-            return game.achievementSystem.getUnlockedAchievements().length;
-        }, ACHIEVEMENT_DEFINITIONS.slice(0, 2).map((d) => d.id));
+        const unlockedCount = await page.evaluate(
+            (firstIds) => {
+                const game = window.__shapeKeeperActiveGame;
+                firstIds.forEach((id) => game.achievementSystem.unlock(id));
+                game.renderAchievementPanel();
+                return game.achievementSystem.getUnlockedAchievements().length;
+            },
+            ACHIEVEMENT_DEFINITIONS.slice(0, 2).map((d) => d.id)
+        );
 
         await expect(page.locator('#achievementCountBadge')).toHaveText(
             `${unlockedCount}/${ACHIEVEMENT_DEFINITIONS.length}`
         );
         const items = page.locator('.achievement-item');
         await expect(items).toHaveCount(unlockedCount);
-        await expect(items.first()).toContainText(
-            ACHIEVEMENT_DEFINITIONS[0].title
-        );
+        await expect(items.first()).toContainText(ACHIEVEMENT_DEFINITIONS[0].title);
     });
 });

--- a/tests/e2e/local-setup.spec.js
+++ b/tests/e2e/local-setup.spec.js
@@ -8,18 +8,14 @@ async function openLocalSetup(page) {
 }
 
 test.describe('Local setup options', () => {
-    test('selecting a grid size enables Start and persists selection', async ({
-        page,
-    }) => {
+    test('selecting a grid size enables Start and persists selection', async ({ page }) => {
         await openLocalSetup(page);
 
         const start = page.locator('#startLocalGame');
         await expect(start).toBeDisabled();
 
         await page.locator('.local-grid-btn[data-size="5"]').click();
-        await expect(
-            page.locator('.local-grid-btn[data-size="5"]')
-        ).toHaveClass(/selected/);
+        await expect(page.locator('.local-grid-btn[data-size="5"]')).toHaveClass(/selected/);
         await expect(start).toBeEnabled();
     });
 
@@ -31,9 +27,7 @@ test.describe('Local setup options', () => {
         await expect(page.locator('#startLocalGame')).toBeEnabled();
     });
 
-    test('AI difficulty is disabled for human opponent and enabled for AI', async ({
-        page,
-    }) => {
+    test('AI difficulty is disabled for human opponent and enabled for AI', async ({ page }) => {
         await openLocalSetup(page);
 
         const opponent = page.getByTestId('local-opponent-type');
@@ -49,9 +43,7 @@ test.describe('Local setup options', () => {
         await expect(difficulty).toBeDisabled();
     });
 
-    test('tutorial toggle is mutually exclusive with AI opponent', async ({
-        page,
-    }) => {
+    test('tutorial toggle is mutually exclusive with AI opponent', async ({ page }) => {
         await openLocalSetup(page);
 
         const opponent = page.getByTestId('local-opponent-type');

--- a/tests/e2e/settings-and-theme.spec.js
+++ b/tests/e2e/settings-and-theme.spec.js
@@ -18,9 +18,7 @@ test.describe('Settings: theme and sound toggles', () => {
         await expect(root).toHaveAttribute('data-theme', 'dark');
         await expect(themeToggle).toHaveAttribute('aria-label', 'Switch to light mode');
 
-        const stored = await page.evaluate(() =>
-            localStorage.getItem('shapekeeper_theme')
-        );
+        const stored = await page.evaluate(() => localStorage.getItem('shapekeeper_theme'));
         expect(stored).toBe('dark');
 
         // reload and confirm persistence


### PR DESCRIPTION
## Summary
Fixes the CI lint gate failures from run [31892169589](https://github.com/TeacherEvan/ShapeKeeper/actions/runs/31892169589/job/95029963130).

The merged `feature/main-menu-cta-rename` (PR #25) introduced 10 prettier/prettier errors in the e2e specs. A full repo re-lint also surfaced a 11th in `settings-and-theme.spec.js` that the truncated CI annotations hid.

## Changes
- `tests/e2e/achievement-panel.spec.js` (9 fixes)
- `tests/e2e/local-setup.spec.js` (4 fixes)
- `tests/e2e/settings-and-theme.spec.js` (1 fix)

All auto-fixed via `eslint --fix` (whitespace/line-wrapping only — no logic changes).

## Verification
- `npm run lint` → 0 errors, 0 warnings
- `npm run test` → 78 passed

🤖 Generated with [Hermes Agent](https://hermes-agent.nousresearch.com)

## Summary by Sourcery

Chores:
- Normalize Playwright e2e spec formatting for achievement panel, local setup, and settings/theme tests to comply with Prettier rules.