### PR TITLE
Potential fix for code scanning alert no. 3: Insecure randomness

### DIFF
--- a/convex-client/shared.js
+++ b/convex-client/shared.js
@@ -65,8 +65,12 @@
             state.convexClient = new ConvexClient(CONVEX_URL);
             state.sessionId = localStorage.getItem('shapekeeper_session_id');
             if (!state.sessionId) {
-                state.sessionId =
-                    'session_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+                const randomBytes = new Uint8Array(8);
+                windowObject.crypto.getRandomValues(randomBytes);
+                const randomSuffix = Array.from(randomBytes, (byte) =>
+                    byte.toString(16).padStart(2, '0')
+                ).join('');
+                state.sessionId = 'session_' + Date.now() + '_' + randomSuffix;
                 localStorage.setItem('shapekeeper_session_id', state.sessionId);
             }
 


### PR DESCRIPTION
Potential fix for [https://github.com/TeacherEvan/ShapeKeeper/security/code-scanning/3](https://github.com/TeacherEvan/ShapeKeeper/security/code-scanning/3)

Use a cryptographically secure random source for the session suffix instead of `Math.random()`. In browser JavaScript, the best fix is `window.crypto.getRandomValues(...)` with explicit byte-to-hex encoding to avoid weak PRNG usage while preserving current behavior (string session ID with timestamp + random suffix).

In `convex-client/shared.js`, update the line creating `state.sessionId` inside `initConvex()` (around lines 68–70). Replace the `Math.random().toString(36).substr(2, 9)` part with a suffix derived from `windowObject.crypto.getRandomValues(new Uint8Array(8))`, converted to hex. This keeps functionality the same (unique opaque ID string stored in localStorage) without relying on insecure randomness. No new imports are needed since this is browser global API usage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Replace insecure session ID randomness with cryptographically secure browser-generated random bytes.