### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-convex.yml
+++ b/.github/workflows/deploy-convex.yml
@@ -9,6 +9,9 @@ on:
             - '.github/workflows/deploy-convex.yml'
     workflow_dispatch: # Allow manual trigger
 
+permissions:
+    contents: read
+
 jobs:
     deploy:
         if: vars.CONVEX_DEPLOY != ''


### PR DESCRIPTION
Potential fix for [https://github.com/TeacherEvan/ShapeKeeper/security/code-scanning/2](https://github.com/TeacherEvan/ShapeKeeper/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to least privilege.  
Best fix here: define workflow-level permissions at the top level (right after `on:` block, before `jobs:`), with `contents: read`. This is sufficient for checkout and typical read-only operations, and does not change existing deploy behavior since deployment uses `CONVEX_DEPLOY_KEY` secret rather than `GITHUB_TOKEN` write scopes.

File to edit:
- `.github/workflows/deploy-convex.yml`

Change to implement:
- Insert:
  - `permissions:`
  - `  contents: read`
- No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Restrict the Convex deployment workflow to the minimum permissions required for read-only repository access.

Bug Fixes:
- Constrain the deploy workflow's `GITHUB_TOKEN` to read-only repository contents permissions.

CI:
- Add explicit least-privilege permissions to the Convex deployment workflow.