### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
         branches:
             - main
 
+permissions:
+    contents: read
+
 jobs:
     test:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/TeacherEvan/ShapeKeeper/security/code-scanning/1](https://github.com/TeacherEvan/ShapeKeeper/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: add workflow-level permissions right after the `on:` block (before `jobs:`), since there is currently only one job and it does not require write scopes.

For this file (`.github/workflows/ci.yml`), add:

- `permissions:`
  - `contents: read`

This preserves current functionality (`actions/checkout` needs contents read) while preventing unnecessary write access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Harden the CI workflow by applying least-privilege permissions to its repository token.

Enhancements:
- Restrict the CI workflow's GITHUB_TOKEN to read-only repository contents access by default.

CI:
- Add explicit least-privilege permissions to the CI workflow.