### PR TITLE
feat: wire lava-timer feature-flag runtime bridge (plan Task 8)

### DIFF
--- a/game.js
+++ b/game.js
@@ -7,6 +7,23 @@
  */
 
 import { DotsAndBoxesGame } from './dots-and-boxes-game.js';
+import { FEATURE_FLAGS } from './constants.js';
+
+// Feature-flag bridge (FR-6). The plan specifies flags are "enabled via
+// window.FEATURE_* at runtime"; this applies any window.FEATURE_LAVA_TIMER /
+// window.FEATURE_SYNC_RESILIENCE set before module load into the static
+// FEATURE_FLAGS object. Without this, the lava timer + sync resilience stay
+// permanently gated-off in the running app (defaults are false in constants.js).
+if (typeof window !== 'undefined') {
+    if (window.FEATURE_LAVA_TIMER === true) FEATURE_FLAGS.FEATURE_LAVA_TIMER = true;
+    if (window.FEATURE_SYNC_RESILIENCE === true) FEATURE_FLAGS.FEATURE_SYNC_RESILIENCE = true;
+    // Expose a live read-only mirror so runtime flag state is inspectable
+    // (e.g. end-to-end tests assert the bridge actually flipped the guard).
+    Object.defineProperty(window, 'FEATURE_FLAGS', {
+        configurable: true,
+        get: () => FEATURE_FLAGS,
+    });
+}
 
 // Export for use in HTML
 window.DotsAndBoxesGame = DotsAndBoxesGame;

--- a/tests/e2e/lava-timer-online-sync.spec.js
+++ b/tests/e2e/lava-timer-online-sync.spec.js
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+import { gotoApp } from './helpers/bootstrap.js';
+
+/**
+ * Task 8 (FR-6 / FR-1) end-to-end gate for the Lava Timer feature flag.
+ *
+ * Proves the plan's stated contract ("flags enabled via window.FEATURE_* at
+ * runtime") actually flips the runtime flag — without the bridge in game.js,
+ * these flags are permanently false and the lava clock is dead code in the
+ * running app. The bridge exposes a live window.FEATURE_FLAGS mirror reflecting
+ * the exact guard renderer.js:108 / turn-clock-controller.js:65 read.
+ */
+
+test.describe('lava timer feature flag gating', () => {
+    test('FEATURE_LAVA_TIMER=true (via window) flips the runtime flag', async ({ page }) => {
+        await page.addInitScript(() => {
+            window.FEATURE_LAVA_TIMER = true;
+            window.FEATURE_SYNC_RESILIENCE = true;
+        });
+        await gotoApp(page);
+
+        // The bridge in game.js must have copied window.* into the live mirror.
+        const flags = await page.evaluate(() => ({
+            lava: window.FEATURE_FLAGS.FEATURE_LAVA_TIMER,
+            sync: window.FEATURE_FLAGS.FEATURE_SYNC_RESILIENCE,
+        }));
+        expect(flags.lava).toBe(true);
+        expect(flags.sync).toBe(true);
+    });
+
+    test('flag defaults OFF when window.FEATURE_LAVA_TIMER is not set', async ({ page }) => {
+        await gotoApp(page);
+
+        const flags = await page.evaluate(() => ({
+            lava: window.FEATURE_FLAGS.FEATURE_LAVA_TIMER,
+            sync: window.FEATURE_FLAGS.FEATURE_SYNC_RESILIENCE,
+        }));
+        expect(flags.lava).toBe(false);
+        expect(flags.sync).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
The Lava Timer & Online Sync Resilience plan (`docs/plans/2026-08-18-lava-timer-and-online-sync.md`) shipped its implementation in #36, but **Task 8's stated contract was never wired**: flags are "enabled via `window.FEATURE_*` at runtime," yet nothing copied `window.FEATURE_LAVA_TIMER` / `window.FEATURE_SYNC_RESILIENCE` into the static `FEATURE_FLAGS` object (which defaults `false` in `constants.js`). Result: the lava clock was permanently gated-off dead code in the running app.

## Changes
- `game.js`: read `window.FEATURE_LAVA_TIMER` / `window.FEATURE_SYNC_RESILIENCE` at module load → apply to `FEATURE_FLAGS`; expose a live read-only `window.FEATURE_FLAGS` mirror (the exact guard `renderer.js:108` / `turn-clock-controller.js:65` read).
- `tests/e2e/lava-timer-online-sync.spec.js`: Task 8 E2E gate proving the `window.FEATURE_*` contract flips the runtime flag (on + default-off).

## Verification
- `npx eslint .` → clean
- `npx vitest run` → 114 passed (no regression)
- `npx playwright test tests/e2e/lava-timer-online-sync.spec.js --project=chromium` → 2 passed
- New E2E only; no source logic touched beyond the flag bridge.

## Note (separate issue, not fixed here)
`tests/e2e/local-gameplay.spec.js:131` (non-adjacent diagonal tap) fails on clean `origin/main` too — confirmed pre-existing and unrelated to this change. Flagging for a standalone fix.

🤖 Generated with Hermes Agent

## Summary by Sourcery

Wire runtime feature-flag configuration into the application so Lava Timer and sync resilience can be enabled as specified.

New Features:
- Enable runtime configuration of the Lava Timer and sync resilience feature flags through window.FEATURE_* values.

Bug Fixes:
- Restore the Lava Timer and sync resilience functionality by correctly applying runtime flags to the guards used by the application.

Enhancements:
- Expose the active feature flags through a read-only window.FEATURE_FLAGS mirror for runtime inspection.

Tests:
- Add end-to-end coverage verifying runtime flag enabling and default-off behavior.