### PR TITLE
feat: ship lava timer + sync resilience ON by default (opt-out via window flag)

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,15 @@
         <script>
             window.CONVEX_URL = 'https://precise-ladybug-504.convex.cloud';
         </script>
+
+        <!-- Feature flags (FR-6). The lava timer + online sync resilience ship ON
+             by default; the runtime bridge in game.js copies window.FEATURE_*
+             into the static FEATURE_FLAGS. Opt a flag out by setting it to false
+             (e.g. window.FEATURE_LAVA_TIMER = false) before the module loads. -->
+        <script>
+            window.FEATURE_LAVA_TIMER = window.FEATURE_LAVA_TIMER ?? true;
+            window.FEATURE_SYNC_RESILIENCE = window.FEATURE_SYNC_RESILIENCE ?? true;
+        </script>
     </head>
 
     <body>

--- a/tests/e2e/lava-timer-online-sync.spec.js
+++ b/tests/e2e/lava-timer-online-sync.spec.js
@@ -4,19 +4,31 @@ import { gotoApp } from './helpers/bootstrap.js';
 /**
  * Task 8 (FR-6 / FR-1) end-to-end gate for the Lava Timer feature flag.
  *
- * This E2E's unique job: prove the plan's stated contract ("flags enabled via
- * window.FEATURE_* at runtime") actually flips the runtime guard. Without the
- * bridge in game.js the flags are permanently false and the lava clock is dead
- * code in the running app. The bridge exposes a live window.FEATURE_FLAGS mirror.
+ * The lava timer + sync resilience ship ON by default (set in index.html via
+ * `window.FEATURE_* ?? true`). The bridge in game.js copies window.FEATURE_*
+ * into the static FEATURE_FLAGS and exposes a live window.FEATURE_FLAGS mirror.
  *
- * NOTE: actual rendering (40% opacity + countdown behind dots in an online
- * match) is proven authoritatively by tests/lava-timer-renders.test.js against
- * the real Renderer.drawLavaTimerLayer(); we do not re-assert drawing here to
- * avoid exposing internal modules on window.
+ * This E2E's job: prove the window.FEATURE_* -> FEATURE_FLAGS bridge works both
+ * ways — default-ON, explicit-ON, and explicit opt-out. Actual rendering (40%
+ * opacity + countdown behind dots in an online match) is proven authoritatively
+ * by tests/lava-timer-renders.test.js against the real Renderer.drawLavaTimerLayer().
  */
 
 test.describe('lava timer feature flag gating', () => {
-    test('FEATURE_LAVA_TIMER=true (via window) flips the runtime flag', async ({ page }) => {
+    test('defaults ON (shipped on) when no window flag is set', async ({ page }) => {
+        await gotoApp(page);
+
+        const flags = await page.evaluate(() => ({
+            lava: window.FEATURE_FLAGS.FEATURE_LAVA_TIMER,
+            sync: window.FEATURE_FLAGS.FEATURE_SYNC_RESILIENCE,
+        }));
+        expect(flags.lava).toBe(true);
+        expect(flags.sync).toBe(true);
+    });
+
+    test('explicit window.FEATURE_LAVA_TIMER=true still flips the runtime flag', async ({
+        page,
+    }) => {
         await page.addInitScript(() => {
             window.FEATURE_LAVA_TIMER = true;
             window.FEATURE_SYNC_RESILIENCE = true;
@@ -31,7 +43,11 @@ test.describe('lava timer feature flag gating', () => {
         expect(flags.sync).toBe(true);
     });
 
-    test('flag defaults OFF when window.FEATURE_LAVA_TIMER is not set', async ({ page }) => {
+    test('flag can be opted OUT via window.FEATURE_LAVA_TIMER=false', async ({ page }) => {
+        await page.addInitScript(() => {
+            window.FEATURE_LAVA_TIMER = false;
+            window.FEATURE_SYNC_RESILIENCE = false;
+        });
         await gotoApp(page);
 
         const flags = await page.evaluate(() => ({


### PR DESCRIPTION
## Summary
Closes the loop on the lava-clock display feature. Previously the lava timer + online sync resilience shipped **gated-off** — only reachable by setting `window.FEATURE_LAVA_TIMER=true`. Per user direction, it now ships **ON by default**.

## Changes
- `index.html`: inline script sets `window.FEATURE_LAVA_TIMER = window.FEATURE_LAVA_TIMER ?? true` (and `FEATURE_SYNC_RESILIENCE` likewise). This preserves the runtime-flag mechanism introduced in #39 — the bridge in `game.js` still copies `window.FEATURE_*` into the static `FEATURE_FLAGS` — while defaulting to ON. Opt out by setting the flag to `false` before the module loads.
- `tests/e2e/lava-timer-online-sync.spec.js`: reworked to reflect default-ON. Asserts three paths through the bridge: shipped-on (no override), explicit `true`, and explicit opt-out `false`.

## Verification
- `npx playwright test tests/e2e/lava-timer-online-sync.spec.js --project=chromium` → **3 passed**
- `npx vitest run` → **117 passed** (incl. `tests/lava-timer-renders.test.js` proving the lava layer actually draws at 0.4 opacity + "7.2s" countdown behind dots in an online match)
- `npx eslint .` → clean

## Notes
- Rendering itself is proven authoritatively by `tests/lava-timer-renders.test.js` (real `Renderer.drawLavaTimerLayer()` + mock 2D context); the E2E's job is the window-flag bridge.
- `tests/e2e/local-gameplay.spec.js:131` (diagonal tap) remains a pre-existing failure on clean `origin/main`, unrelated to this change.

🤖 Generated with Hermes Agent

## Summary by Sourcery

Ship the lava timer and online sync resilience enabled by default with support for opting out through window flags.

New Features:
- Enable the lava timer and online sync resilience by default while retaining runtime opt-out flags.

Enhancements:
- Expand end-to-end coverage for default-enabled, explicitly enabled, and opted-out feature flag behavior.

Tests:
- Update lava timer feature-flag tests to validate the shipped default and runtime override paths.