### PR TITLE
chore: enable esbuild postinstall + refresh transitive lock deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -912,9 +912,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2627,9 +2627,9 @@
             "license": "CC0-1.0"
         },
         "node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
         "prettier": "^3.7.4",
         "typescript": "^5.9.3",
         "vitest": "^4.1.0"
+    },
+    "allowScripts": {
+        "esbuild@0.27.0": true
     }
 }


### PR DESCRIPTION
## Summary
Standalone, user-intended dependency hygiene change (not bundled with feature work):
- `package.json`: add `allowScripts.esbuild@0.27.0 = true` so esbuild's native-binary postinstall runs (required for build tooling).
- `package-lock.json`: refresh transitive deps to match — `ajv` 6.12.6 → 6.15.0, `minimatch` 3.1.2 → 3.1.5.

## Verification
- `npm ci` → clean (186 packages, 0 vulnerabilities)
- esbuild native binary resolves: `esbuild OK 0.27.0`
- `npx vitest run` → 117/117 (no regression from dep drift)

## Note
This is a dependency/lockfile change only; no source or `AGENTS.md`/`CLAUDE.md`/`convex/_generated` touched.

🤖 Generated with Hermes Agent

## Summary by Sourcery

Enable esbuild’s native binary setup and update transitive dependency versions in the lockfile.

Enhancements:
- Enable esbuild’s native binary installation during dependency setup and refresh transitive lockfile dependencies.

Build:
- Allow the esbuild 0.27.0 postinstall script to run.